### PR TITLE
fix: avoid false timeout on CNIPA result pages

### DIFF
--- a/tests/test_cnipa_epub_crawler.py
+++ b/tests/test_cnipa_epub_crawler.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from cnipa_epub_crawler import submit_index_search
+
+
+class SubmitIndexSearchTests(unittest.TestCase):
+    def test_uses_committed_navigation_and_result_title_instead_of_full_load(self) -> None:
+        page = MagicMock()
+
+        submit_index_search(page, "数据标注")
+
+        page.expect_navigation.assert_called_once_with(timeout=120_000, wait_until="commit")
+        page.wait_for_function.assert_called_once()
+        title_condition = page.wait_for_function.call_args.args[0]
+        self.assertIn("专利查询结果展示", title_condition)
+        self.assertIn("无查询结果", title_condition)
+        page.wait_for_load_state.assert_not_called()
+        page.wait_for_timeout.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cnipa_epub_crawler.py
+++ b/tools/cnipa_epub_crawler.py
@@ -12,8 +12,8 @@
 2. 新建浏览器上下文：设定 **桌面 Chrome UA**、**zh-CN**、固定 **视口**（见 ``_new_context``），使请求形态接近普通用户浏览器。
 3. ``page.goto`` 站点首页，**wait_until="load"**。
 4. **等待首页可检索**：首页在访客到达后会先经 **前端脚本/WAF 一类逻辑**，未通过前 **不会出现** 检索输入框 ``#searchStr``。本实现通过 **周期性轮询 DOM**（每 3 秒一次，总时长见 ``EPUB_WAF_MAX_WAIT_SEC``，默认 180s）直到 ``#searchStr`` 出现；**不是**用 requests 直接 POST 能等价替代的步骤。
-5. ``page.fill`` 将关键词写入 ``#searchStr``，对 ``#indexForm`` 执行 **submit**（而非单独点按钮），并 ``expect_navigation`` 等待结果页 **load**。
-6. 结果页 **安定等待**：依次尝试 **load / networkidle**（超时则忽略），再 **固定短时 sleep**，减轻列表/统计脚本未跑完就取 HTML 导致的空壳或半截 DOM。
+5. ``page.fill`` 将关键词写入 ``#searchStr``，对 ``#indexForm`` 执行 **submit**（而非单独点按钮），并等待结果页导航 **commit**。
+6. 等待页面标题变为 **「专利查询结果展示」或「无查询结果」**，以结果 DOM 是否可用为准，不等待该站可能始终不触发的完整 ``load``。
 7. ``page.content()`` 取全页 HTML；若处于导航中抛错则 **重试退避**（``_safe_page_content``），避免竞态。
 8. 后续解析由 **`cnipa_epub_parse.py`** 完成（本文件 ``search_epub_keyword`` 内会调用）。
 
@@ -97,18 +97,6 @@ def wait_for_epub_home_ready(page: Page, *, max_wait_sec: float | None = None) -
     )
 
 
-def _wait_result_page_settled(page: Page) -> None:
-    try:
-        page.wait_for_load_state("load", timeout=30_000)
-    except Exception:
-        pass
-    try:
-        page.wait_for_load_state("networkidle", timeout=25_000)
-    except Exception:
-        pass
-    page.wait_for_timeout(800)
-
-
 def _safe_page_content(page: Page, *, max_attempts: int = 10) -> str:
     last_err: Exception | None = None
     for i in range(max_attempts):
@@ -131,7 +119,7 @@ def _safe_page_content(page: Page, *, max_attempts: int = 10) -> str:
 
 def submit_index_search(page: Page, keyword: str) -> None:
     page.fill("#searchStr", keyword)
-    with page.expect_navigation(timeout=120_000, wait_until="load"):
+    with page.expect_navigation(timeout=120_000, wait_until="commit"):
         form = page.query_selector("#indexForm")
         if form:
             form.evaluate("el => el.submit()")
@@ -142,7 +130,13 @@ def submit_index_search(page: Page, keyword: str) -> None:
                 if (f) f.submit();
             }"""
             )
-    _wait_result_page_settled(page)
+    page.wait_for_function(
+        """() => {
+            const title = document.title.trim();
+            return title === "专利查询结果展示" || title === "无查询结果";
+        }""",
+        timeout=120_000,
+    )
 
 
 def fetch_epub_result_html(


### PR DESCRIPTION
## English

### Summary

- wait for the CNIPA result navigation to commit, then wait for a known result-page title
- remove full `load` / `networkidle` waits that can time out after the result DOM is already usable
- add a regression test for a result page that never finishes loading

### Root cause

The CNIPA `/Dxb/IndexQuery` page can contain the complete search result DOM while `document.readyState` remains `loading`. Waiting for Playwright's full `load` state therefore raises a false timeout even though results can already be parsed.

### Impact

The default Playwright backend now reads both normal result pages and zero-result pages without waiting for unrelated page resources to finish.

### Validation

- `python -m unittest tests.test_cnipa_epub_crawler -v`
- `python tools/cnipa_epub_search.py 身份门控` → exit 0 with `EPUB_HITS_JSON: []`
- `python tests/test_cnipa_epub_chain.py 数据标注` → exit 0 with 3 results and abstracts

Related to #8: this fixes the existing default Playwright path; the alternative backend proposed there does not change this synchronization behavior.

---

## 中文

### 修改概述

- 等待国知局结果页导航提交完成，再等待已知的结果页标题
- 移除完整的 `load` / `networkidle` 等待，避免结果 DOM 已可用后仍发生超时
- 新增回归测试，覆盖结果页始终无法完成加载的场景

### 根因

国知局 `/Dxb/IndexQuery` 页面可能已经包含完整的检索结果 DOM，但 `document.readyState` 仍保持为 `loading`。因此，等待 Playwright 的完整 `load` 状态会产生误超时，即使结果实际上已经可以解析。

### 影响

默认 Playwright 后端现在可以正常读取普通结果页和零结果页，无需等待与检索结果无关的页面资源完成加载。

### 验证

- `python -m unittest tests.test_cnipa_epub_crawler -v`
- `python tools/cnipa_epub_search.py 身份门控` → 退出码为 0，返回 `EPUB_HITS_JSON: []`
- `python tests/test_cnipa_epub_chain.py 数据标注` → 退出码为 0，返回 3 条包含摘要的结果

与 #8 相关：本 PR 修复现有的默认 Playwright 路径；#8 提议的替代浏览器后端并未改变该同步逻辑。
