### PR TITLE
test: restore CNIPA class-code fixtures

### DIFF
--- a/tests/crawl/fixtures/epub_item_ipc.html
+++ b/tests/crawl/fixtures/epub_item_ipc.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<div class="overview-default">
+<div class="item">
+  <h1 class="title">合成 IPC 分类号测试卡片</h1>
+  <dl>
+    <dt>申请公布号：</dt><dd>CN123456789A</dd>
+    <dt>分类号：</dt><dd>B01J20/26；B01D53/02</dd>
+    <dt>专利代理</dt>
+  </dl>
+</div>
+</div>

--- a/tests/crawl/fixtures/epub_item_loc.html
+++ b/tests/crawl/fixtures/epub_item_loc.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<div class="overview-default">
+<div class="item">
+  <h1 class="title">合成 LOC 分类号测试卡片</h1>
+  <dl>
+    <dt>申请公布号：</dt><dd>CN987654321S</dd>
+    <dt>分类号：</dt><dd>26-05</dd>
+    <dt>专利代理</dt>
+  </dl>
+</div>
+</div>


### PR DESCRIPTION
## Summary\n- restore the two synthetic HTML fixtures used by the CNIPA IPC/LOC parser tests\n- keep the fixtures local to the crawl test suite and free of real patent, personal, or customer data\n\n## Validation\n- python -m unittest crawl parser and form-filter tests: 25 passed using an in-memory Playwright import stub; no browser launch or network access\n- python -m unittest discover -s tests/shared -t .: 90 passed, 5 skipped\n- python -m unittest discover -s tests/patent_reader -t .: 20 passed\n- python -m unittest discover -s tests/oa -t .: 17 passed\n\nThe normal crawl suite still requires the repository-declared Playwright package before import; this PR does not alter that runtime dependency.