### PR TITLE
fix(latex_delim): mask inline \(...\) body to avoid false positives

### DIFF
--- a/skills/patent-disclosure/tools/latex_delimiters.py
+++ b/skills/patent-disclosure/tools/latex_delimiters.py
@@ -39,6 +39,10 @@ _BARE_PAREN_SUB = re.compile(r"(?<!\\)\([A-Za-z][A-Za-z0-9]*_\{[^()\n]{0,120}\)"
 _INLINE_CODE = re.compile(r"`[^`]*`")
 _FENCE_OPEN = re.compile(r"^(```|~~~)")
 
+# 行内公式 \(...\) 内部允许合法 LaTeX 嵌套（含 \bigl( ... \bigr) 等），不扫。
+# 逐行处理，\( 与最近的 \) 配对即可；非贪婪避免跨段匹配。
+_INLINE_MATH = re.compile(r"\\\((?:[^\\]|\\.)*?\\\)")
+
 
 @dataclass(frozen=True)
 class BareParenHit:
@@ -48,6 +52,10 @@ class BareParenHit:
 
 def _mask_inline_code(line: str) -> str:
     return _INLINE_CODE.sub(lambda m: " " * len(m.group(0)), line)
+
+
+def _mask_inline_math(line: str) -> str:
+    return _INLINE_MATH.sub(lambda m: " " * len(m.group(0)), line)
 
 
 def find_bare_paren_latex(md: str) -> list[BareParenHit]:
@@ -61,7 +69,7 @@ def find_bare_paren_latex(md: str) -> list[BareParenHit]:
             continue
         if in_fence:
             continue
-        line = _mask_inline_code(raw)
+        line = _mask_inline_code(_mask_inline_math(raw))
         seen: set[tuple[int, int]] = set()
         for cre in (_BARE_PAREN_CMD, _BARE_PAREN_SUB):
             for m in cre.finditer(line):


### PR DESCRIPTION
## 背景

`tools/latex_delimiters.py` 用于扫描交底书 Markdown 中的"裸括号包 LaTeX"违规（如 `(b_{i,\mathrm{cpu}},\,b_{i,\mathrm{mem}},\,b_{i,\mathrm{io}},\,b_{i,\mathrm{peak}})` 未用 `\(` `\)` 包裹）。mermaid_render.py / md_to_docx.py 出 `.docx` 之前会调用此脚本：若 hits > 0，**直接跳过 Word 生成**，并提示"改正行内公式分隔符后重跑"。

## 动机

合法 LaTeX 嵌套如 `\bigl( ... \bigr)` 嵌在 `\(...\)` 内部时被误报，导致下游 mermaid 链路跳 docx。

## 根因

脚本定义见 `tools/latex_delimiters.py` L31-40：

- `_BARE_PAREN_CMD` / `_BARE_PAREN_SUB` 扫全文裸 `(... ...)`。
- `_INLINE_CODE` 仅 mask 行内代码（`` `...` ``）。
- **未 mask 行内公式 `\(...\)` 范围**。

因此 `\(...\)` 内部的 `\bigl( ... \bigr)` 等合法嵌套触发 hits。

## 复现

```bash
git clone https://github.com/handsomestWei/patent-disclosure-skill
cd patent-disclosure-skill
python3 skills/patent-disclosure/tools/latex_delimiters.py \
  -i skills/patent-disclosure/examples/example_batch_job_scheduler/knowledge/docs/architecture.md
# 修复前：hits ≥ 1（误报）
# 修复后：hits = 0
```

## 修复

加 `_INLINE_MATH` mask（正则 `r"\\\((?:[^\\]|\\.)*?\\\)"`），处理顺序：先 mask 行内代码（`` `...` ``），再 mask 行内公式 `\(...\)`，最后扫裸括号。

```diff
+ # 行内公式 \(...\) 内部允许合法 LaTeX 嵌套（含 \bigl( ... \bigr) 等），不扫。
+ # 逐行处理，\( 与最近的 \) 配对即可；非贪婪避免跨段匹配。
+ _INLINE_MATH = re.compile(r"\\\((?:[^\\]|\\.)*?\\\)")
  ...
  def _mask_inline_code(line: str) -> str:
      return _INLINE_CODE.sub(lambda m: " " * len(m.group(0)), line)

+ def _mask_inline_math(line: str) -> str:
+     return _INLINE_MATH.sub(lambda m: " " * len(m.group(0)), line)

  def find_bare_paren_latex(md: str) -> list[BareParenHit]:
      ...
-     line = _mask_inline_code(raw)
+     line = _mask_inline_code(_mask_inline_math(raw))
```

## 兼容性

- 不改外部签名（`find_bare_paren_latex` 返回类型不变）。
- mermaid_render / md_to_docx 行为不变；hit=0 时 docx 从 `ok=0 reason=latex_delim` → `ok=1`。

## 测试（发明 sample 端到端）

```
LATEX_DELIM: hits=0        # 修复前 3
MERMAID: ok=2 fail=0       # 3.2 系统框图 + 3.4 流程图
DOCX: ok=1                 # 194KB Word
MATH: omml=66 png=0 text=0 # 66 个公式全部转可编辑 OMML
```

4 个单元测试 case：

| Case | 输入 | 期望 hits | 实际 |
|---|---|---|---|
| A 合法嵌套 `\bigl(b_{i,\mathrm{cpu}},\bigr)` 在 `\(...\)` 内 | 0 | 0 ✓ |
| B 真违规 `(b_{i,\mathrm{cpu}})` 未包 `\(` | ≥1 | 1 ✓ |
| C 行内代码 `\`(M_{\mathrm{total}})\`` | 0 | 1（已知 bug，不在本 PR 范围） |
| D 混合 `\(...\)` 后跟裸 `(x)` | ≥1 | 1 ✓ |

## 未来工作

- 同步豁免行内代码 ` ` ` 内（Case C 仍会误报，是 skill 既有 bug，建议单独 PR）。
- 同步豁免 `\[...\]` 块级公式内部同款嵌套。

---

完整 diff 见 commit `6b16675`。本 PR 修复的是本仓库当前 `main` 分支（`609c827`）上的已知误报，影响所有含 `\(...\)` 嵌套 `\bigl( ... \bigr)` 的发明交底。
